### PR TITLE
First attempt on CDI managed health procedures

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/org/eclipse/microprofile/health/HealthCheckProcedure.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HealthCheckProcedure.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health;
+
+/**
+ * The basic health check procedure interface
+ *
+ * @author Heiko Braun
+ * @since 13.06.17
+ */
+public interface HealthCheckProcedure {
+    HealthStatus execute();
+}

--- a/api/src/main/java/org/eclipse/microprofile/health/HttpBinding.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HttpBinding.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Heiko Braun
+ */
+@ApplicationScoped
+@Path("/health")
+public class HttpBinding {
+
+    @Inject
+    @Any
+    Instance<org.eclipse.microprofile.health.HealthCheckProcedure> procedures;
+
+    @GET
+    @Produces(value = "application/json")
+    public Response checkHealth() {
+
+        if (null == procedures) {
+            return Response.ok().status(204).build();
+        }
+
+        List<org.eclipse.microprofile.health.HealthStatus> responses = new ArrayList<>();
+
+        for (org.eclipse.microprofile.health.HealthCheckProcedure procedure : procedures) {
+            org.eclipse.microprofile.health.HealthStatus status = procedure.execute();
+            responses.add(status);
+        }
+
+        StringBuffer sb = new StringBuffer("{");
+        sb.append("\"checks\": [\n");
+
+        int i = 0;
+        boolean failed = false;
+
+        for (org.eclipse.microprofile.health.HealthStatus resp : responses) {
+
+            sb.append(resp.toJson());
+
+            if (!failed) {
+                failed = resp.getState() != Status.State.UP;
+            }
+
+            if (i < responses.size() - 1) {
+                sb.append(",\n");
+            }
+            i++;
+        }
+        sb.append("],\n");
+
+        String outcome = failed ? "DOWN" : "UP";
+        sb.append("\"outcome\": \"" + outcome + "\"\n");
+        sb.append("}\n");
+
+        return Response.ok(sb.toString()).build();
+    }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
                 <artifactId>cdi-api</artifactId>
                 <version>1.2</version>
             </dependency>
+          <dependency>
+                <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+                <version>1.0.0.Final</version>
+              </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>

--- a/ri/README.adoc
+++ b/ri/README.adoc
@@ -1,11 +1,26 @@
 
+# Health API Reference Implementation Notes
+
 The RI TCK coverage currently depends on custom Wildfly Swarm branch:
 
  https://github.com/heiko-braun/wildfly-swarm-1/tree/mp_health_api
 
 
-Test execution is disabled by default and can be enabled with:
+Since this is not published to maven central, test execution is disabled by default and can be enabled with:
 
 ```
 mvn -Dmaven.test.skip=false test
 ```
+
+## Building the RI
+
+
+```
+git clone https://github.com/heiko-braun/wildfly-swarm-1 health-ri
+cd health-ri
+mvn clean install
+```
+
+
+
+

--- a/ri/README.adoc
+++ b/ri/README.adoc
@@ -1,7 +1,11 @@
 
 The RI TCK coverage currently depends on custom Wildfly Swarm branch:
- 
+
  https://github.com/heiko-braun/wildfly-swarm-1/tree/mp_health_api
- 
- 
-It's pretty much work in progress...
+
+
+Test execution is disabled by default and can be enabled with:
+
+```
+mvn -Dmaven.test.skip=false test
+```

--- a/ri/pom.xml
+++ b/ri/pom.xml
@@ -66,12 +66,18 @@
 
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
+            <artifactId>cdi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
             <artifactId>monitor</artifactId>
         </dependency>
 
         <!-- TCK -->
 
         <dependency>
+
             <groupId>org.eclipse.microprofile.health.tck</groupId>
             <artifactId>microprofile-health-tck</artifactId>
             <version>1.0-SNAPSHOT</version>

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CDIHealthCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CDIHealthCheck.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck.deployment;
+
+import javax.enterprise.context.Dependent;
+
+import org.eclipse.microprofile.health.HealthCheckProcedure;
+import org.eclipse.microprofile.health.HealthStatus;
+
+/**
+ * @author Heiko Braun
+ * @since 13.06.17
+ */
+@Dependent
+public class CDIHealthCheck implements HealthCheckProcedure {
+    @Override
+    public HealthStatus execute() {
+        return HealthStatus.named("CDI").up();
+    }
+}


### PR DESCRIPTION
```
package org.eclipse.microprofile.health.tck.deployment;

[...]

public class CDIHealthCheck implements HealthCheckProcedure {
    @Override
    public HealthStatus execute() {
        return HealthStatus.named("CDI").up();
    }
}
```