### PR TITLE
update to dependency version and a couple of new NOTICE files

### DIFF
--- a/api/NOTICE
+++ b/api/NOTICE
@@ -1,0 +1,13 @@
+=========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for Microprofile Health                  ==
+=========================================================================
+
+SPDXVersion: SPDX-2.1
+PackageName: Eclipse Microprofile
+PackageHomePage: http://www.eclipse.org/microprofile
+PackageLicenseDeclared: Apache-2.0
+
+PackageCopyrightText: <text>
+Heiko Braun hbraun@redhat.com
+</text>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.1.12.Final</version>
+                <version>1.1.13.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/ri/NOTICE
+++ b/ri/NOTICE
@@ -1,0 +1,13 @@
+=========================================================================
+==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+==  Version 2.0, in this case for Microprofile Health                  ==
+=========================================================================
+
+SPDXVersion: SPDX-2.1
+PackageName: Eclipse Microprofile
+PackageHomePage: http://www.eclipse.org/microprofile
+PackageLicenseDeclared: Apache-2.0
+
+PackageCopyrightText: <text>
+Heiko Braun hbraun@redhat.com
+</text>

--- a/ri/pom.xml
+++ b/ri/pom.xml
@@ -31,9 +31,9 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <arquillian.version>1.1.7.Final</arquillian.version>
+        <arquillian.version>1.1.13.Final</arquillian.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
-        <wildfly-swarm.version>2017.7.0-SNAPSHOT</wildfly-swarm.version>
+        <wildfly-swarm.version>2017.4.0</wildfly-swarm.version>
 
         <!-- skip the tests run's until we have a RI distribution -->
         <maven.test.skip>true</maven.test.skip>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -31,7 +31,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <arquillian.version>1.1.7.Final</arquillian.version>
+        <arquillian.version>1.1.13.Final</arquillian.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
         <junit.version>4.12</junit.version>
     </properties>


### PR DESCRIPTION
Reverted Heiko's recent merge ( #6 ) since that version of swarm does not seem to exist in maven...  And, in order for my changes to build correctly, I had to revert to a working version of swarm -- 2017.4.0.  Heiko can redo his changes once a proper version of swarm is detected and tested.

This is in support of Issue #5.