### PR TITLE
[TCK] Health URL is configurable

### DIFF
--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -19,6 +19,17 @@
 
 The TCK uses `JUnit`.
 
+== Health URL
+
+Implementation of the MicroProfile Health TCK can set a System property that corresponds to the HTTP endpoint that the
+ TCK calls to check the health:
+
+```
+org.eclipse.microprofile.health.tck.url
+```
+
+The default is http://localhost:8080/health[http://localhost:8080/health].
+
 == Dependencies
 
 To enable the tests in your project you need to add the following dependency to your build:
@@ -53,6 +64,9 @@ If you use Apache Maven then the tests are run via the `maven-surefire-plugin`, 
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+                <systemPropertyVariables>
+                    <org.eclipse.microprofile.health.tck.url>http://localhost:8080/health</org.eclipse.microprofile.health.tck.url>
+                </systemPropertyVariables>
                 <dependenciesToScan>
                     <dependency>org.eclipse.microprofile.health.tck:microprofile-health-tck</dependency>
                 </dependenciesToScan>
@@ -62,6 +76,7 @@ If you use Apache Maven then the tests are run via the `maven-surefire-plugin`, 
 </build>
 ----
 
+Note that the `org.eclipse.microprofile.health.tck.url` System property is also explicitely set in the `maven-surefire-plugin` configuration.
 == Examples
 
 The https://github.com/jmesnil/wildfly-microprofile-health[WildFly implementation] of the MicroProfile Health runs the TCK in its https://github.com/jmesnil/wildfly-microprofile-health/tree/master/tck[tck module].

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
@@ -23,6 +23,7 @@
 package org.eclipse.microprofile.health.tck;
 
 import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
 
 import org.eclipse.microprofile.health.tck.deployment.FailedCheck;
 import org.eclipse.microprofile.health.tck.deployment.SuccessfulCheck;
@@ -63,7 +64,7 @@ public class MultipleProceduresFailedTest extends SimpleHttp {
     @Test
     @RunAsClient
     public void testFailureResponsePayload() throws Exception {
-        Response response = getUrlContents("http://localhost:8080/health");
+        Response response = getUrlContents(getHealthURL());
 
         // status code
         Assert.assertEquals(503, response.getStatus());

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/ResponseAttributesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/ResponseAttributesTest.java
@@ -23,6 +23,7 @@
 package org.eclipse.microprofile.health.tck;
 
 import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
 
 import org.eclipse.microprofile.health.tck.deployment.CheckWithAttributes;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -61,7 +62,7 @@ public class ResponseAttributesTest extends SimpleHttp {
     @Test
     @RunAsClient
     public void testSuccessResponsePayload() throws Exception {
-        Response response = getUrlContents("http://localhost:8080/health");
+        Response response = getUrlContents(getHealthURL());
 
         // status code
         Assert.assertEquals(200, response.getStatus());

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
@@ -23,6 +23,7 @@
 package org.eclipse.microprofile.health.tck;
 
 import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
 
 import org.eclipse.microprofile.health.tck.deployment.FailedCheck;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -60,7 +61,7 @@ public class SingleProcedureFailedTest extends SimpleHttp {
     @Test
     @RunAsClient
     public void testFailureResponsePayload() throws Exception {
-        Response response = getUrlContents("http://localhost:8080/health");
+        Response response = getUrlContents(getHealthURL());
 
         // status code
         Assert.assertEquals(503, response.getStatus());

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
@@ -23,6 +23,7 @@
 package org.eclipse.microprofile.health.tck;
 
 import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
 
 import org.eclipse.microprofile.health.tck.deployment.SuccessfulCheck;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -60,7 +61,7 @@ public class SingleProcedureSuccessfulTest extends SimpleHttp {
     @Test
     @RunAsClient
     public void testSuccessResponsePayload() throws Exception {
-        Response response = getUrlContents("http://localhost:8080/health");
+        Response response = getUrlContents(getHealthURL());
 
         // status code
         Assert.assertEquals(200, response.getStatus());

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/TCKConfiguration.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/TCKConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
+ */
+public class TCKConfiguration {
+
+   private TCKConfiguration() {
+   }
+
+   public static String getHealthURL() {
+      return System.getProperty("org.eclipse.microprofile.health.tck.url", "http://localhost:8080/health");
+   }
+}


### PR DESCRIPTION
Implementations that runs the TCK can configure the HTTP health URL with
the System property org.eclipse.microprofile.health.tck.url (default is
http://localhost:8080/health).