### PR TITLE
Added a test to verify delegation across injection targets works

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.microprofile.health.tck;
+
+import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
+
+import org.eclipse.microprofile.health.tck.deployment.DelegateCheck;
+import org.eclipse.microprofile.health.tck.deployment.DelegationTarget;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.io.StringReader;
+
+/**
+ * @author Heiko Braun
+ */
+@RunWith(Arquillian.class)
+public class DelegateProcedureSuccessfulTest extends SimpleHttp {
+
+    @Deployment
+    public static Archive getDeployment() throws Exception {
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class, "tck.war");
+        deployment.addClass(DelegateCheck.class);
+        deployment.addClass(DelegationTarget.class);
+        return deployment;
+    }
+
+    /**
+     * Verifies CDI scoped beans can be used as delegate to resolve the system state
+     */
+    @Test
+    @RunAsClient
+    public void testSuccessfulDelegateInvocation() throws Exception {
+        Response response = getUrlContents(getHealthURL());
+
+        // status code
+        Assert.assertEquals(200, response.getStatus());
+
+        JsonReader jsonReader = Json.createReader(new StringReader(response.getBody().get()));
+        JsonObject json = jsonReader.readObject();
+
+        // response size
+        JsonArray checks = json.getJsonArray("checks");
+        Assert.assertEquals("Expected a single check response", 1, checks.size());
+
+
+        // single procedure response
+        Assert.assertEquals(
+                "Expected a dependent CDI bean to be invoked, to resolve the system state",
+                "delegate-check",
+                asJsonObject(checks.get(0)).getString("id")
+        );
+
+        Assert.assertEquals(
+                "Expected a successful check result",
+                "UP",
+                asJsonObject(checks.get(0)).getString("result")
+        );
+
+        // overall outcome
+        Assert.assertEquals(
+                "Expected overall outcome to be successful",
+                "UP",
+                json.getString("outcome")
+        );
+    }
+}
+

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
@@ -22,20 +22,15 @@
 
 package org.eclipse.microprofile.health.tck;
 
-import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
-import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
-
 import org.eclipse.microprofile.health.tck.deployment.DelegateCheck;
 import org.eclipse.microprofile.health.tck.deployment.DelegationTarget;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -43,10 +38,12 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 import java.io.StringReader;
 
+import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
+
 /**
  * @author Heiko Braun
  */
-@RunWith(Arquillian.class)
 public class DelegateProcedureSuccessfulTest extends SimpleHttp {
 
     @Deployment
@@ -73,27 +70,27 @@ public class DelegateProcedureSuccessfulTest extends SimpleHttp {
 
         // response size
         JsonArray checks = json.getJsonArray("checks");
-        Assert.assertEquals("Expected a single check response", 1, checks.size());
+        Assert.assertEquals(checks.size(), 1, "Expected a single check response");
 
 
         // single procedure response
         Assert.assertEquals(
-                "Expected a dependent CDI bean to be invoked, to resolve the system state",
+                asJsonObject(checks.get(0)).getString("id"),
                 "delegate-check",
-                asJsonObject(checks.get(0)).getString("id")
-        );
+                "Expected a dependent CDI bean to be invoked, to resolve the system state"
+                );
 
         Assert.assertEquals(
-                "Expected a successful check result",
+                asJsonObject(checks.get(0)).getString("result"),
                 "UP",
-                asJsonObject(checks.get(0)).getString("result")
+                "Expected a successful check result"
         );
 
         // overall outcome
         Assert.assertEquals(
-                "Expected overall outcome to be successful",
+                json.getString("outcome"),
                 "UP",
-                json.getString("outcome")
+                "Expected overall outcome to be successful"
         );
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegateCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegateCheck.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck.deployment;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.Response;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/**
+ * Created by hbraun on 18.08.17.
+ */
+@ApplicationScoped
+public class DelegateCheck implements HealthCheck {
+
+    @Inject
+    private DelegationTarget delegate;
+
+    @Override
+    public Response call() {
+        return Response.named("delegate-check").state(delegate.isTheSystemHealthy());
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegationTarget.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegationTarget.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck.deployment;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Created by hbraun on 18.08.17.
+ */
+@ApplicationScoped
+public class DelegationTarget {
+
+    public boolean isTheSystemHealthy() {
+        return true;
+    }
+}


### PR DESCRIPTION
We probably need more extensive tests to verify all sorts of CDI discovery and injection scenarios, but this test at least  verifies that beans that are discovered as `HealthChecks` are actually managed beans (i.e. `@Inject`) works on them. 

This is a sanity test and more needs to follow, but as a baseline this should work for 1.0 I think
