### PR TITLE
Fix #53: Added @Health annotation to TCK deployments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -87,9 +87,10 @@ public class SuccessfulCheck implements HealthCheck {
 
 ### Integration with CDI
 
-Within CDI contexts, beans that implement `HealthCheck` are discovered automatically and are invoked by the framework or runtime when the outermost protocol entry point (i.e. `http://HOST:PORT/health`) receives an inbound request.
+Within CDI contexts, beans that implement `HealthCheck` and annotated with `@Health` are discovered automatically and are invoked by the framework or runtime when the outermost protocol entry point (i.e. `http://HOST:PORT/health`) receives an inbound request.
 
 ```
+@Health
 @ApplicationScoped
 public class CheckDiskpace implements HealthCheck {
 

--- a/api/src/main/java/org/eclipse/microprofile/health/Health.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/Health.java
@@ -19,27 +19,17 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  */
-package org.eclipse.microprofile.health.tck.deployment;
+package org.eclipse.microprofile.health;
 
-import org.eclipse.microprofile.health.Health;
-import org.eclipse.microprofile.health.HealthCheck;
-import org.eclipse.microprofile.health.HealthCheckResponse;
-
-import javax.enterprise.context.ApplicationScoped;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Created by hbraun on 29.06.17.
+ * Created by hbraun on 24.08.17.
  */
-@Health
-@ApplicationScoped
-public class CheckWithAttributes implements HealthCheck {
-
-    @Override
-    public HealthCheckResponse call() {
-        return HealthCheckResponse.named("attributes-check")
-                .withData("first-key", "first-val")
-                .withData("second-key", "second-val")
-                .up()
-                .build();
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Health {
 }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/EnforceQualifierTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/EnforceQualifierTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.microprofile.health.tck;
+
+import org.eclipse.microprofile.health.tck.deployment.CheckWithoutQualifier;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
+
+/**
+ * @author Heiko Braun
+ */
+public class EnforceQualifierTest extends SimpleHttp {
+
+    @Deployment
+    public static Archive getDeployment() throws Exception {
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class, "tck.war");
+        deployment.addClass(CheckWithoutQualifier.class);
+        return deployment;
+    }
+
+    /**
+     * Verifies the health integration with CDI at the scope of a server runtime
+     */
+    @Test
+    @RunAsClient
+    public void testFailureResponsePayload() throws Exception {
+        Response response = getUrlContents(getHealthURL());
+
+        // the procedure with an annotation shold not be discovered
+        Assert.assertEquals(response.getStatus(), 204);
+    }
+}
+

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CheckWithoutQualifier.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CheckWithoutQualifier.java
@@ -21,25 +21,20 @@
  */
 package org.eclipse.microprofile.health.tck.deployment;
 
-import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
 import javax.enterprise.context.ApplicationScoped;
 
 /**
- * Created by hbraun on 29.06.17.
+ * @author Heiko Braun
+ * @since 13.06.17
  */
-@Health
+// lacks the @Health annotation and should not be discovered
 @ApplicationScoped
-public class CheckWithAttributes implements HealthCheck {
-
+public class CheckWithoutQualifier implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
-        return HealthCheckResponse.named("attributes-check")
-                .withData("first-key", "first-val")
-                .withData("second-key", "second-val")
-                .up()
-                .build();
+        return HealthCheckResponse.named("check-without-annotation").up().build();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegateCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegateCheck.java
@@ -21,6 +21,7 @@
  */
 package org.eclipse.microprofile.health.tck.deployment;
 
+import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
@@ -30,6 +31,7 @@ import javax.inject.Inject;
 /**
  * Created by hbraun on 18.08.17.
  */
+@Health
 @ApplicationScoped
 public class DelegateCheck implements HealthCheck {
 

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/FailedCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/FailedCheck.java
@@ -21,6 +21,7 @@
  */
 package org.eclipse.microprofile.health.tck.deployment;
 
+import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
@@ -30,6 +31,7 @@ import javax.enterprise.context.ApplicationScoped;
  * @author Heiko Braun
  * @since 13.06.17
  */
+@Health
 @ApplicationScoped
 public class FailedCheck implements HealthCheck {
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/SuccessfulCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/SuccessfulCheck.java
@@ -21,6 +21,7 @@
  */
 package org.eclipse.microprofile.health.tck.deployment;
 
+import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
@@ -30,6 +31,7 @@ import javax.enterprise.context.ApplicationScoped;
  * @author Heiko Braun
  * @since 13.06.17
  */
+@Health
 @ApplicationScoped
 public class SuccessfulCheck implements HealthCheck {
     @Override


### PR DESCRIPTION
This commit also includes a test to verify that only procedures with `@Health` will be discovered (enforcement)