### PR TITLE
Issue #3, do not use 204 when no procedures are installed

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
@@ -47,7 +47,7 @@ public abstract class HealthCheckResponse {
     private static volatile HealthCheckResponseProvider factory = null;
 
     /**
-     * Set the SPIFactory instance. It is used by OSGi environment while service loader
+     * Set the HealthCheckResponseProvider instance. It is used by OSGi environment while service loader
      * pattern is not supported.
      *
      * @param factory the factory instance to use.
@@ -56,8 +56,11 @@ public abstract class HealthCheckResponse {
         HealthCheckResponse.factory = factory;
     }
 
-    public static HealthCheckResponseBuilder named(String name) {
-
+    /**
+     * Create an empty health check response
+     * @return the response builder instance
+     */
+    public static HealthCheckResponseBuilder builder() {
         if (factory == null) {
             synchronized (HealthCheckResponse.class) {
                 if (factory != null) {
@@ -67,14 +70,23 @@ public abstract class HealthCheckResponse {
                 HealthCheckResponseProvider newInstance = find(HealthCheckResponseProvider.class);
 
                 if (newInstance == null) {
-                    throw new IllegalStateException("No SPIFactory implementation found!");
+                    throw new IllegalStateException("No HealthCheckResponseProvider implementation found!");
                 }
 
                 factory = newInstance;
             }
         }
 
-        return factory.createResponseBuilder().name(name);
+        return factory.createResponseBuilder();
+    }
+
+    /**
+     * Create a health check response with a procedure with the given name.
+     * @param name - the name of the health check procedure
+     * @return the response builder instance
+     */
+    public static HealthCheckResponseBuilder named(String name) {
+        return builder().name(name);
     }
 
     // the actual contract

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -76,7 +76,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <sourceDocumentName>microprofile-config-spec.asciidoc</sourceDocumentName>
+                    <sourceDocumentName>microprofile-health-spec.asciidoc</sourceDocumentName>
                     <sourceHighlighter>coderay</sourceHighlighter>
                     <attributes>
                         <license>Apache License v2.0</license>

--- a/spec/src/main/asciidoc/microprofile-health-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-health-spec.asciidoc
@@ -36,7 +36,6 @@ endif::[]
 
 include::license-alv2.asciidoc[]
 
-=== Microprofile Proposal - WORK IN PROGRESS!
+include::architecture.asciidoc[]
 
-
-TODO
+include::protocol-wireformat.adoc[]

--- a/spec/src/main/asciidoc/protocol-wireformat.adoc
+++ b/spec/src/main/asciidoc/protocol-wireformat.adoc
@@ -99,6 +99,7 @@ Health checks are used to signal the state of a computing node to other machines
 8. The consumer determines the overall outcome
 
 # Protocol Specifics
+This section describes the specifics of the HTTP protocol usage.
 
 ## Interacting with producers
 How are the health checks accessed and invoked ?
@@ -144,7 +145,7 @@ Each provider MUST provide the REST/HTTP interaction, but MAY provide other prot
 # Health Check Procedures
 * A producer MUST support custom, application level health check procedures
 * A producer SHOULD support reasonable out-of-the-box procedures
-* A producer without health check procedures installed MUST returns positive overall outcome (i.e. HTTP 204, no content)
+* A producer without health check procedures installed MUST returns positive overall outcome (i.e. HTTP 200)
 
 ## Policies to determine the overall outcome
 
@@ -167,14 +168,13 @@ Aspects regarding the secure access of health check information.
 | Context       | Verb          | Status Code  | Response
 | /health
 | GET
-| 200, 204, 500, 503
+| 200, 500, 503
 | See Appendix B
 |===
 
 ## Status Codes:
 
 * 200 for a health check with a positive outcome
-* 204 in case no health check procedures are installed into the runtime
 * 503 in case the overall outcome is negative
 * 500 in case the consumer wasn’t able to process the health check request (i.e. error in procedure)
 
@@ -187,15 +187,15 @@ The following table give valid health check responses:
 | Request | HTTP Status       | JSON Payload         | State  | Comment
 | /health
 | 200
-| Yes, see below
+| Yes
 | UP
-| Check with payload
+| Check with payload. See <<With procedures installed into the runtime>>.
 
 | /health
-| 204
+| 200
 | No
 | UP
-| Check without procedures installed
+| Check without procedures installed. See <<Without procedures installed into the runtime>>
 
 | /health
 | 503
@@ -294,5 +294,6 @@ Status 503
 ```
 
 ## Without procedures installed into the runtime
-Status 204
-No payload, as required by https://tools.ietf.org/html/rfc7231#section-6.3.5
+Status 200 without a Content-Type response header and no response body.
+A status 204(https://tools.ietf.org/html/rfc7231#section-6.3.5) cannot be generally used in cloud environments, so that is
+not utilized in this specification.

--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -17,7 +17,7 @@
 
 = Running the MicroProfile Health TCK
 
-The TCK uses `JUnit`.
+The TCK uses `TestNG`.
 
 == Health URL
 

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck;
+
+import org.eclipse.microprofile.health.tck.deployment.SuccessfulEmptyCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.eclipse.microprofile.health.tck.TCKConfiguration.getHealthURL;
+
+/**
+ * Validates that a health check that includes no procedures returns a 200 status with no body.
+ * @author Scott Stark
+ */
+public class NoProcedureSuccessfulTest extends SimpleHttp {
+
+    @Deployment
+    public static Archive getDeployment() throws Exception {
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class, "tck.war");
+        deployment.addClass(SuccessfulEmptyCheck.class);
+        return deployment;
+    }
+
+    /**
+     * Verifies the health integration with CDI at the scope of a server runtime
+     */
+    @Test
+    @RunAsClient
+    public void testSuccessResponsePayload() throws Exception {
+        Response response = getUrlContents(getHealthURL());
+
+        // status code
+        Assert.assertEquals(response.getStatus(),200);
+
+        // There should be no body
+        Assert.assertFalse(response.getBody().isPresent(), "Expected no body");
+        // TODO: check for Content-Type?
+    }
+}
+

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/SuccessfulEmptyCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/SuccessfulEmptyCheck.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck.deployment;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+/**
+ * A health check that indicates an up status without any procedure information.
+ */
+public class SuccessfulEmptyCheck  implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.builder().up().build();
+    }
+}


### PR DESCRIPTION
Note that this required the addition of a new factory method in HealthCheckResponse to allow for the creation of a HealthCheckResponse without any procedure checks. See the org.eclipse.microprofile.health.tck.deployment.SuccessfulEmptyCheck deployment class.

Signed-off-by: Scott Stark <starksm64@gmail.com>