### PR TITLE
Introduce @Health as an actual qualifier

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,6 +27,13 @@
     <artifactId>microprofile-health-api</artifactId>
     <name>MicroProfile Health API</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/api/src/main/java/org/eclipse/microprofile/health/Health.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/Health.java
@@ -21,6 +21,7 @@
  */
 package org.eclipse.microprofile.health;
 
+import javax.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -29,6 +30,7 @@ import java.lang.annotation.Target;
 /**
  * Created by hbraun on 24.08.17.
  */
+@Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Health {

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,16 @@
                 <artifactId>cdi-api</artifactId>
                 <version>1.2</version>
             </dependency>
-          <dependency>
+            <dependency>
                 <groupId>org.jboss.spec.javax.ws.rs</groupId>
                 <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
                 <version>1.0.0.Final</version>
-              </dependency>
+            </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
+            </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
@@ -80,18 +85,18 @@
 
     <build>
         <pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${checkstyle.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
-            </plugin>
-        </plugins>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${checkstyle.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+            </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
@@ -116,72 +121,73 @@
                     <logViolationsToConsole>true</logViolationsToConsole>
                     <checkstyleRules>
                         <module name="Checker">
-                            <module name="SuppressionCommentFilter" />
+                            <module name="SuppressionCommentFilter"/>
                             <module name="FileLength">
-                                <property name="max" value="3500" />
-                                <property name="fileExtensions" value="java" />
+                                <property name="max" value="3500"/>
+                                <property name="fileExtensions" value="java"/>
                             </module>
-                            <module name="FileTabCharacter" />
+                            <module name="FileTabCharacter"/>
                             <module name="TreeWalker">
-                                <module name="FileContentsHolder" />
-                               <module name="ConstantName">
-                                    <property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$" />
+                                <module name="FileContentsHolder"/>
+                                <module name="ConstantName">
+                                    <property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$"/>
                                 </module>
-                                <module name="LocalVariableName" />
+                                <module name="LocalVariableName"/>
                                 <module name="MethodName">
-                                    <property name="format" value="${checkstyle.methodNameFormat}" />
+                                    <property name="format" value="${checkstyle.methodNameFormat}"/>
                                 </module>
-                                <module name="PackageName" />
-                                <module name="LocalFinalVariableName" />
-                                <module name="ParameterName" />
-                                <module name="StaticVariableName" />
+                                <module name="PackageName"/>
+                                <module name="LocalFinalVariableName"/>
+                                <module name="ParameterName"/>
+                                <module name="StaticVariableName"/>
 
                                 <module name="TypeName">
-                                    <property name="format" value="^_?[A-Z][a-zA-Z0-9]*$|packageinfo" />
+                                    <property name="format" value="^_?[A-Z][a-zA-Z0-9]*$|packageinfo"/>
                                 </module>
                                 <module name="AvoidStarImport">
-                                    <property name="excludes" value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context" />
+                                    <property name="excludes"
+                                              value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context"/>
                                 </module>
-                                <module name="IllegalImport" />
-                                <module name="RedundantImport" />
-                                <module name="UnusedImports" />
+                                <module name="IllegalImport"/>
+                                <module name="RedundantImport"/>
+                                <module name="UnusedImports"/>
                                 <module name="LineLength">
-                                    <property name="max" value="150" />
-                                    <property name="ignorePattern" value="@version|@see" />
+                                    <property name="max" value="150"/>
+                                    <property name="ignorePattern" value="@version|@see"/>
                                 </module>
                                 <module name="MethodLength">
-                                    <property name="max" value="250" />
+                                    <property name="max" value="250"/>
                                 </module>
                                 <module name="ParameterNumber">
-                                    <property name="max" value="11" />
+                                    <property name="max" value="11"/>
                                 </module>
                                 <module name="EmptyBlock">
-                                    <property name="option" value="text" />
+                                    <property name="option" value="text"/>
                                 </module>
-                                <module name="NeedBraces" />
+                                <module name="NeedBraces"/>
                                 <module name="LeftCurly">
-                                    <property name="option" value="EOL" />
+                                    <property name="option" value="EOL"/>
                                 </module>
                                 <module name="RightCurly">
-                                    <property name="option" value="ALONE" />
+                                    <property name="option" value="ALONE"/>
                                 </module>
-                                <module name="EmptyStatement" />
-                                <module name="EqualsHashCode" />
-                                <module name="DefaultComesLast" />
-                                <module name="MissingSwitchDefault" />
-                                <module name="FallThrough" />
-                                <module name="MultipleVariableDeclarations" />
+                                <module name="EmptyStatement"/>
+                                <module name="EqualsHashCode"/>
+                                <module name="DefaultComesLast"/>
+                                <module name="MissingSwitchDefault"/>
+                                <module name="FallThrough"/>
+                                <module name="MultipleVariableDeclarations"/>
                                 <module name="com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck">
-                                    <property name="severity" value="ignore" />
+                                    <property name="severity" value="ignore"/>
                                 </module>
-                                <module name="HideUtilityClassConstructor" />
+                                <module name="HideUtilityClassConstructor"/>
                                 <module name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck">
-                                    <property name="packageAllowed" value="false" />
-                                    <property name="protectedAllowed" value="true" />
-                                    <property name="publicMemberPattern" value="^serialVersionUID" />
-                                    <property name="severity" value="warning" />
+                                    <property name="packageAllowed" value="false"/>
+                                    <property name="protectedAllowed" value="true"/>
+                                    <property name="publicMemberPattern" value="^serialVersionUID"/>
+                                    <property name="severity" value="warning"/>
                                 </module>
-                                <module name="UpperEll" />
+                                <module name="UpperEll"/>
                             </module>
                         </module>
                     </checkstyleRules>
@@ -195,7 +201,9 @@
                 <executions>
                     <execution>
                         <id>rat-check</id>
-                        <goals><goal>check</goal></goals>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>


### PR DESCRIPTION
This is to resolve an issue introduced with #53, it was decided ot use @Health to demarcate classes that should be health checks.  However, for that to work we need the qualifier to actually be a qualifier.