### PR TITLE
Fix Misnamed Methods in README and Java-API Doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,9 +21,9 @@
 
 ## Motivation
 
-Health checks are used to probe the state of a computing node from another other machine (i.e. kubernetes service controller) with the primary target being cloud infrastructure environments where automated processes maintain the state of computing nodes.
+Health checks are used to probe the state of a computing node from another machine (i.e. kubernetes service controller) with the primary target being cloud infrastructure environments where automated processes maintain the state of computing nodes.
 
-In this scenario _health checks are used to determine if a computing node needs to be discarded (terminated, shutdown)_ and eventually replaced by another (healthy) instance.
+In this scenario, _health checks are used to determine if a computing node needs to be discarded (terminated, shutdown)_ and eventually replaced by another (healthy) instance.
 
 It’s not intended (although could be used) as a monitoring solution for human operators.
 
@@ -31,7 +31,7 @@ It’s not intended (although could be used) as a monitoring solution for human 
 
 The proposed solution breaks down into two parts:
 
-- A health checks protocol and wireformat
+- A health check protocol and wireformat
 - A Java API to implement health check procedures
 
 ## Detailed design
@@ -67,7 +67,7 @@ public abstract class HealthCheckResponse {
 
     public abstract State getState();
 
-    public abstract Optional<Map<String, Object>> getAttributes();
+    public abstract Optional<Map<String, Object>> getData();
 
     [...]
 }

--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -43,7 +43,7 @@ public abstract class HealthCheckResponse {
 
     public abstract State getState();
 
-    public abstract Optional<Map<String, Object>> getAttributes();
+    public abstract Optional<Map<String, Object>> getData();
 
     [...]
 }


### PR DESCRIPTION
Presumably these were missed during the refactor of `getAttributes()` to `getData()`.

Also fixes a couple of typos:
* Removes the redundant word _other_ from line 24
* Made _health checks_ singular on line 34, as it probably shouldn't be plural
* Adds in a comma on line 26  for readability