### PR TITLE
Add a .build() for the response to be built. 

### DIFF
--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -59,7 +59,7 @@ Application level code is expected to use one of static methods on `HealthCheckR
 public class SuccessfulCheck implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
-        return HealthCheckResponse.named("successful-check").up();
+        return HealthCheckResponse.named("successful-check").up().build();
     }
 }
 ```


### PR DESCRIPTION
As stated in #111 the JavaApi example in the spec does not compile.
