### PR TITLE
microprofile-health-119 Clarify integration with CDI

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/health/Health.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/Health.java
@@ -28,6 +28,7 @@ import java.lang.annotation.RetentionPolicy;
 
 /**
  * Created by hbraun on 24.08.17.
+ * @deprecated in version 1.1 of the spec.
  */
 @Qualifier
 @Documented

--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -84,11 +84,14 @@ public class CheckDiskspace implements HealthCheck {
 
 = Integration with CDI
 
-Within CDI contexts, beans that implement `HealthCheck` and annotated with `@Health`
-are discovered automatically and are invoked by runtime when the outermost protocol entry point (i.e. `http://HOST:PORT/health`) receives an inbound request.
+Any enabled bean with a bean of type `org.eclipse.microprofile.health.HealthCheck` and default qualifier that can be used as health check procedure.
+
+In addition, for backward compatibility with version 1.0 of the current specification, any enabled bean with a bean of type `org.eclipse.microprofile.health.HealthCheck` and `@Health` qualifier.
+
+Contextual references of health check procedures are invoked by runtime when the outermost protocol entry point (i.e. `http://HOST:PORT/health`) receives an inbound request
+
 
 ```
-@Health
 @ApplicationScoped
 public class MyCheck implements HealthCheck {
 

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CheckWithAttributes.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CheckWithAttributes.java
@@ -30,7 +30,6 @@ import javax.enterprise.context.ApplicationScoped;
 /**
  * Created by hbraun on 29.06.17.
  */
-@Health
 @ApplicationScoped
 public class CheckWithAttributes implements HealthCheck {
 

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CheckWithHealthQualifier.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CheckWithHealthQualifier.java
@@ -21,6 +21,7 @@
  */
 package org.eclipse.microprofile.health.tck.deployment;
 
+import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
@@ -30,11 +31,11 @@ import javax.enterprise.context.ApplicationScoped;
  * @author Heiko Braun
  * @since 13.06.17
  */
-// lacks the @Health annotation and should not be discovered
+@Health
 @ApplicationScoped
-public class CheckWithoutQualifier implements HealthCheck {
+public class CheckWithHealthQualifier implements HealthCheck {
     @Override
     public HealthCheckResponse call() {
-        return HealthCheckResponse.named("check-without-annotation").up().build();
+        return HealthCheckResponse.named("check-with-annotation").up().build();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegateCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelegateCheck.java
@@ -31,7 +31,6 @@ import javax.inject.Inject;
 /**
  * Created by hbraun on 18.08.17.
  */
-@Health
 @ApplicationScoped
 public class DelegateCheck implements HealthCheck {
 

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/FailedCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/FailedCheck.java
@@ -31,7 +31,6 @@ import javax.enterprise.context.ApplicationScoped;
  * @author Heiko Braun
  * @since 13.06.17
  */
-@Health
 @ApplicationScoped
 public class FailedCheck implements HealthCheck {
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/SuccessfulCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/SuccessfulCheck.java
@@ -31,7 +31,6 @@ import javax.enterprise.context.ApplicationScoped;
  * @author Heiko Braun
  * @since 13.06.17
  */
-@Health
 @ApplicationScoped
 public class SuccessfulCheck implements HealthCheck {
     @Override


### PR DESCRIPTION
Solving #119:
2 CDI beans with type HealthCheck type and Default or Health qualifier exist

Signed-off-by: Antoine Sabot-Durand <antoine@sabot-durand.net>