### PR TITLE
Setting testable to false for deployments in TCK

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
@@ -44,7 +44,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class DelegateProcedureSuccessfulTest extends SimpleHttp {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(DelegateCheck.class, DelegationTarget.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/HealthCheckResponseAttributesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/HealthCheckResponseAttributesTest.java
@@ -44,7 +44,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class HealthCheckResponseAttributesTest extends SimpleHttp {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(CheckWithAttributes.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
@@ -45,7 +45,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class MultipleProceduresFailedTest extends SimpleHttp {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(FailedCheck.class, SuccessfulCheck.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
@@ -40,7 +40,7 @@ import static org.eclipse.microprofile.health.tck.DeploymentUtils.createEmptyWar
  */
 public class NoProcedureSuccessfulTest extends SimpleHttp {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive getDeployment() throws Exception {
         return createEmptyWarFile();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
@@ -43,7 +43,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class SingleProcedureFailedTest extends SimpleHttp {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(FailedCheck.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
@@ -43,7 +43,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class SingleProcedureSuccessfulTest extends SimpleHttp {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(SuccessfulCheck.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/WithQualifierTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/WithQualifierTest.java
@@ -49,7 +49,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class WithQualifierTest extends SimpleHttp {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(CheckWithHealthQualifier.class);
     }


### PR DESCRIPTION
Setting testable to false for deployments in TCK, all the tests are `@RunAsClient`
Details about test run modes in https://docs.jboss.org/author/display/ARQ/Test+run+modes

Execution of current TCK causes warnings on server side
```
Failed to define class org.eclipse.microprofile.health.tck.SingleProcedureSuccessfulTest in Module "deployment.tck.war" from Service Module Loader:
java.lang.NoClassDefFoundError: Failed to link org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest
(Module "deployment.tck.war" from Service Module Loader): org/eclipse/microprofile/health/tck/SimpleHttp
```

