### PR TITLE
Revert "Rename global outcome to status Rename check state to status"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -103,15 +103,15 @@ public class CheckDiskSpace implements HealthCheck {
 === On the wire
 
 It's the responsibility of the runtime to gather all `HealthCheckResponse` s for `HealthCheck` s known to the runtime. This means an inbound HTTP request will lead to a series of invocations
- on health check procedures and the runtime will provide a composite response, with a single overall status, i.e.:
+ on health check procedures and the runtime will provide a composite response, with a single overall outcome, i.e.:
 
   ```
   {
-    "status": "UP",
+    "outcome": "UP",
     "checks": [
       {
         "name": "first-check",
-        "status": "UP",
+        "state": "UP",
         "data": {
           "key": "foo",
           "foo": "bar"
@@ -119,7 +119,7 @@ It's the responsibility of the runtime to gather all `HealthCheckResponse` s for
       },
       {
           "name": "second-check",
-          "status": "UP"
+          "state": "UP"
       }
     ]
   }

--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -49,7 +49,7 @@ public abstract class HealthCheckResponse {
 }
 ```
 
-The status of all `HealthCheck` 's determines the overall status.
+The status of all `HealthCheck` 's determines the overall outcome.
 
 == Constructing `HealthCheckResponse`s
 

--- a/spec/src/main/asciidoc/protocol-wireformat.adoc
+++ b/spec/src/main/asciidoc/protocol-wireformat.adoc
@@ -64,8 +64,8 @@ Note that the force of these words is modified by the requirement level of the d
 | Health Check Procedure
 | The code executed to determine the liveliness of a Producer
 
-| Producer status
-| The overall status, determined by considering all health check procedure results
+| Producer Outcome
+| The overall outcome, determined by considering all health check procedure results
 
 | Health check procedure result
 | The result of single check
@@ -76,11 +76,11 @@ Note that the force of these words is modified by the requirement level of the d
 1. Consumer invokes the health check of a Producer through any of the supported protocols
 2. Producer enforces security constraints on the invocation (i.e authentication)
 3. Producer executes a set of Health check procedures (could be a set with one element)
-4. Producer determines the overall status
-5. The status is mapped to outermost protocol (i.e. HTTP status codes)
+4. Producer determines the overall outcome (Producer outcome)
+5. The outcome is mapped to outermost protocol (i.e. HTTP status codes)
 6. The payload is written to the response stream
 7. The consumer reads the response
-8. The consumer determines the overall status
+8. The consumer determines the overall outcome
 
 === Protocol Specifics
 This section describes the specifics of the HTTP protocol usage.
@@ -95,10 +95,9 @@ Health checks (innermost) can and should be mapped to the actual invocation prot
 
 * Producers MAY support a variety of protocols but the information items in the response payload MUST remain the same.
 * Producers SHOULD define a well known default context to perform checks
-* Each response SHOULD integrate with the outermost protocol whenever it makes sense (i.e. using HTTP status codes to
-signal the overall status)
+* Each response SHOULD integrate with the outermost protocol whenever it makes sense (i.e. using HTTP status codes to signal the overall state)
 * Inner protocol information items MUST NOT be replaced by outer protocol information items, rather kept redundantly.
-* The inner protocol response MUST be self-contained, that is carrying all information needed to reason about the producer status
+* The inner protocol response MUST be self-contained, that is carrying all information needed to reason about the producer outcome
 
 === Mandatory and optional protocol types
 
@@ -115,7 +114,7 @@ Each provider MUST provide the REST/HTTP interaction, but MAY provide other prot
 * The primary information MUST be boolean, it needs to be consumed by other machines. Anything between available/unavailable doesn’t make sense or would increase the complexity on the side of the consumer processing that information.
 * The response information MAY contain an additional information holder
 * Consumers MAY process the additional information holder or simply decide to ignore it
-* The response information MUST contain the boolean `status` of each check
+* The response information MUST contain the boolean state of each check
 * The response information MUST contain the name of each check
 
 === Wireformats
@@ -124,22 +123,22 @@ Each provider MUST provide the REST/HTTP interaction, but MAY provide other prot
 * Producers MAY  support an additional information holder with key/value pairs to provide further context (i.e. disk.free.space=120mb).
 * The JSON response payload MUST be compatible with the one described in Appendix B
 * The JSON response MUST contain the `name` entry specifying the name of the check, to support protocols that support external identifier (i.e. URI)
-* The JSON response MUST contain the `status` entry specifying the state as String: “UP” or “DOWN”
+* The JSON response MUST contain the `state` entry specifying the state as String: “UP” or “DOWN”
 * The JSON MAY support an additional information holder to carry key value pairs that provide additional context
 
 == Health Check Procedures
 * A producer MUST support custom, application level health check procedures
 * A producer SHOULD support reasonable out-of-the-box procedures
-* A producer with no health check procedures expected or installed MUST return positive overall status (i.e. HTTP 200)
-* A producer with health check procedures expected but not yet installed MUST return negative overall status (i.e. HTTP 503)
+* A producer with no health check procedures expected or installed MUST return positive overall outcome (i.e. HTTP 200)
+* A producer with health check procedures expected but not yet installed MUST return negative overall outcome (i.e. HTTP 503)
 
-=== Policies to determine the overall status
+=== Policies to determine the overall outcome
 
-When multiple procedures are installed all procedures MUST be executed and the overall status needs to be determined.
+When multiple procedures are installed all procedures MUST be executed and the overall outcome needs to be determined.
 
-* Consumers MUST support a logical conjunction policy to determine the status
-* Consumers MUST use the logical conjunction policy by default to determine the status
-* Consumers MAY support custom policies to determine the status
+* Consumers MUST support a logical conjunction policy to determine the outcome
+* Consumers MUST use the logical conjunction policy by default to determine the outcome
+* Consumers MAY support custom policies to determine the outcome
 
 ==== Executing procedures
 
@@ -168,8 +167,8 @@ Aspects regarding the secure access of health check information.
 
 === Status Codes:
 
-* 200 for a health check with a positive status (`UP`)
-* 503 in case the overall status is negative (`DOWN`)
+* 200 for a health check with a positive outcome
+* 503 in case the overall outcome is negative
 * 500 in case the producer wasn’t able to process the health check request (i.e. error in procedure)
 
 
@@ -219,7 +218,7 @@ The following table give valid health check responses:
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
-   "status": {
+   "outcome": {
      "type": "string"
    },
    "checks": {
@@ -230,7 +229,7 @@ The following table give valid health check responses:
          "name": {
            "type": "string"
          },
-         "status": {
+         "state": {
            "type": "string"
          },
          "data": {
@@ -247,13 +246,13 @@ The following table give valid health check responses:
        },
        "required": [
          "name",
-         "status"
+         "state"
          ]
      }
    }
  },
  "required": [
-   "status",
+   "outcome",
    "checks"
  ]
 }
@@ -267,11 +266,11 @@ Status `200` and the following payload:
 
 ```
 {
-  "status": "UP",
+  "outcome": "UP",
   "checks": [
     {
       "name": "myCheck",
-      "status": "UP",
+      "state": "UP",
       "data": {
         "key": "value",
         "foo": "bar"
@@ -285,11 +284,11 @@ Status `503` and the following payload:
 
 ```
 {
-  "status": "DOWN",
+  "outcome": "DOWN",
   "checks": [
     {
       "name": "firstCheck",
-      "status": "DOWN",
+      "state": "DOWN",
       "data": {
         "key": "value",
         "foo": "bar"
@@ -297,7 +296,7 @@ Status `503` and the following payload:
     },
     {
       "name": "secondCheck",
-      "status": "UP"
+      "state": "UP"
     }
   ]
 }
@@ -329,7 +328,7 @@ Status `200` and the following payload:
 
 ```
 {
-  "status": "UP",
+  "outcome": "UP",
   "checks": []
 }
 ```

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
@@ -76,16 +76,16 @@ public class DelegateProcedureSuccessfulTest extends SimpleHttp {
                 );
 
         Assert.assertEquals(
-                asJsonObject(checks.get(0)).getString("status"),
+                asJsonObject(checks.get(0)).getString("state"),
                 "UP",
                 "Expected a successful check result"
         );
 
         // overall outcome
         Assert.assertEquals(
-                json.getString("status"),
+                json.getString("outcome"),
                 "UP",
-                "Expected overall status to be successful"
+                "Expected overall outcome to be successful"
         );
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/HealthCheckResponseAttributesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/HealthCheckResponseAttributesTest.java
@@ -78,7 +78,7 @@ public class HealthCheckResponseAttributesTest extends SimpleHttp {
                 );
 
         Assert.assertEquals(
-                asJsonObject(check).getString("status"),
+                asJsonObject(check).getString("state"),
                 "UP",
                 "Expected a successful check result"
                 );
@@ -97,7 +97,7 @@ public class HealthCheckResponseAttributesTest extends SimpleHttp {
 
         // overall outcome
         Assert.assertEquals(
-                json.getString("status"),
+                json.getString("outcome"),
                 "UP",
                 "Expected overall outcome to be successful"
                 );

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
@@ -86,9 +86,9 @@ public class MultipleProceduresFailedTest extends SimpleHttp {
 
         // overall outcome
         Assert.assertEquals(
-                json.getString("status"),
+                json.getString("outcome"),
                 "DOWN",
-                "Expected overall status to be unsuccessful"
+                "Expected overall outcome to be unsuccessful"
         );
     }
 
@@ -101,7 +101,7 @@ public class MultipleProceduresFailedTest extends SimpleHttp {
                 );
 
         Assert.assertEquals(
-                asJsonObject(check).getString("status"),
+                asJsonObject(check).getString("state"),
                 "DOWN",
                 "Expected a successful check result"
                 );
@@ -116,7 +116,7 @@ public class MultipleProceduresFailedTest extends SimpleHttp {
                 );
 
         Assert.assertEquals(
-                asJsonObject(check).getString("status"),
+                asJsonObject(check).getString("state"),
                 "UP",
                 "Expected a successful check result"
                 );

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
@@ -58,8 +58,9 @@ public class NoProcedureSuccessfulTest extends SimpleHttp {
 
         JsonReader jsonReader = Json.createReader(new StringReader(response.getBody().get()));
         JsonObject json = jsonReader.readObject();
+        System.out.println(json);
 
-        Assert.assertEquals(json.getString("status"), "UP","Expected status UP");
+        Assert.assertEquals(json.getString("outcome"), "UP","Expected outcome UP");
         Assert.assertTrue(json.getJsonArray("checks").isEmpty(), "Expected empty checks array");
 
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
@@ -75,16 +75,16 @@ public class SingleProcedureFailedTest extends SimpleHttp {
         );
 
         Assert.assertEquals(
-                asJsonObject(checks.get(0)).getString("status"),
+                asJsonObject(checks.get(0)).getString("state"),
                 "DOWN",
                 "Expected a successful check result"
         );
 
         // overall outcome
         Assert.assertEquals(
-                json.getString("status"),
+                json.getString("outcome"),
                 "DOWN",
-                "Expected overall status to be unsuccessful"
+                "Expected overall outcome to be unsuccessful"
         );
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
@@ -75,16 +75,16 @@ public class SingleProcedureSuccessfulTest extends SimpleHttp {
         );
 
         Assert.assertEquals(
-                asJsonObject(checks.get(0)).getString("status"),
+                asJsonObject(checks.get(0)).getString("state"),
                 "UP",
                 "Expected a successful check result"
         );
 
         // overall outcome
         Assert.assertEquals(
-                json.getString("status"),
+                json.getString("outcome"),
                 "UP",
-                "Expected overall status to be successful"
+                "Expected overall outcome to be successful"
         );
     }
 }


### PR DESCRIPTION
This reverts commit 44665d3b3ec3f3e88631e7f06984fe8bd1f01f76.

Renaming outcome/state to status/status is a breaking change that should not be done under a 1.1 release.

Undoing #125 & #127 since these changes break back compat without bringing us into compliance with any standard.