### PR TITLE
Revert "Setting testable to false for deployments in TCK"

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/DelegateProcedureSuccessfulTest.java
@@ -44,7 +44,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class DelegateProcedureSuccessfulTest extends SimpleHttp {
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(DelegateCheck.class, DelegationTarget.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/EnforceQualifierTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/EnforceQualifierTest.java
@@ -41,7 +41,7 @@ import static org.eclipse.microprofile.health.tck.DeploymentUtils.createWarFileW
  */
 public class EnforceQualifierTest extends SimpleHttp {
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(CheckWithoutQualifier.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/HealthCheckResponseAttributesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/HealthCheckResponseAttributesTest.java
@@ -44,7 +44,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class HealthCheckResponseAttributesTest extends SimpleHttp {
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(CheckWithAttributes.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/MultipleProceduresFailedTest.java
@@ -45,7 +45,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class MultipleProceduresFailedTest extends SimpleHttp {
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(FailedCheck.class, SuccessfulCheck.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/NoProcedureSuccessfulTest.java
@@ -40,7 +40,7 @@ import static org.eclipse.microprofile.health.tck.DeploymentUtils.createEmptyWar
  */
 public class NoProcedureSuccessfulTest extends SimpleHttp {
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive getDeployment() throws Exception {
         return createEmptyWarFile();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureFailedTest.java
@@ -43,7 +43,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class SingleProcedureFailedTest extends SimpleHttp {
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(FailedCheck.class);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/SingleProcedureSuccessfulTest.java
@@ -43,7 +43,7 @@ import static org.eclipse.microprofile.health.tck.JsonUtils.asJsonObject;
  */
 public class SingleProcedureSuccessfulTest extends SimpleHttp {
 
-    @Deployment(testable = false)
+    @Deployment
     public static Archive getDeployment() throws Exception {
         return createWarFileWithClasses(SuccessfulCheck.class);
     }


### PR DESCRIPTION
This reverts commit 45e96cd8856ba74d244ba13104ffe5350a900a59.

testable = false in deployments prohibits any addition of resources (classes, service loader) to the deployment that is created by the TCK which is something implementations typically probably need to do.

Signed-off-by: xstefank xstefank122@gmail.com