### PR TITLE
Add DelayedCheckTest TCK

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/DelayedCheckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/DelayedCheckTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck;
+
+import org.eclipse.microprofile.health.tck.deployment.DelayedCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import static org.eclipse.microprofile.health.tck.DeploymentUtils.createWarFileWithClasses;
+
+/**
+ * @author Martin Stefanko
+ */
+public class DelayedCheckTest extends TCKBase {
+
+    @Deployment
+    public static Archive getDeployment() {
+        return createWarFileWithClasses(DelayedCheck.class);
+    }
+
+    /**
+     * Verifies the health integration with CDI when the bean creation takes longer than
+     * the first request
+     */
+    @Test
+    @RunAsClient
+    public void testSuccessResponsePayload() {
+        Response response = getUrlReadyContents();
+
+        // status code
+        Assert.assertEquals(response.getStatus(),503);
+
+        JsonObject json = readJson(response);
+
+        // response size
+        JsonArray checks = json.getJsonArray("checks");
+        Assert.assertEquals(checks.size(), 1, "Expected a single check response");
+
+        // single procedure response
+        assertFailureCheck(checks.getJsonObject(0), "delayed-check");
+
+        assertOverallFailure(json);
+    }
+}
+

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelayedCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/DelayedCheck.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck.deployment;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@Readiness
+@ApplicationScoped
+public class DelayedCheck implements HealthCheck {
+    
+    public DelayedCheck() {
+        // delay the bean creation
+        try {
+            Thread.sleep(3000);
+        } 
+        catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("delayed-check").down().build();
+    }
+}


### PR DESCRIPTION
Signed-off-by: xstefank <xstefank122@gmail.com>

This TCK tests validates that if health check creation (here Readiness check) takes some time, the requests that are received before the health check instance is created report the right answer -- essentially meaning that all health checks must be invoked when request comes.