### PR TITLE
Add TCK for JSON schema validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,7 @@
                         <exclude>.checkstyle</exclude>
                         <exclude>.factorypath</exclude>
                         <exclude>.editorconfig</exclude>
+                        <exclude>src/main/resources/**/*</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -110,6 +110,12 @@
             <version>${version.glassfish.json}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.java-json-tools</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>2.2.10</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/JsonSchemaValidationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/JsonSchemaValidationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.microprofile.health.tck;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import org.eclipse.microprofile.health.tck.deployment.SuccessfulHealth;
+import org.eclipse.microprofile.health.tck.deployment.SuccessfulLiveness;
+import org.eclipse.microprofile.health.tck.deployment.SuccessfulReadiness;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.json.JsonObject;
+import java.io.IOException;
+
+import static org.eclipse.microprofile.health.tck.DeploymentUtils.createWarFileWithClasses;
+
+/**
+ * @author Martin Stefanko
+ */
+public class JsonSchemaValidationTest extends TCKBase {
+
+    @Deployment
+    public static Archive getDeployment() {
+        return createWarFileWithClasses(SuccessfulHealth.class,
+            SuccessfulLiveness.class, SuccessfulReadiness.class);
+    }
+
+    /**
+     * Verifies that the JSON object returned by the implementation is following the 
+     * JSON schema defined by the specification
+     */
+    @Test
+    @RunAsClient
+    public void testFailureResponsePayload() throws Exception {
+        Response response = getUrlHealthContents();
+
+        Assert.assertEquals(response.getStatus(), 200);
+
+        JsonObject json = readJson(response);
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode schemaJson = mapper.readTree(Thread.currentThread()
+            .getContextClassLoader().getResourceAsStream("health-check-schema.json"));
+
+        final JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
+        final JsonSchema schema = factory.getJsonSchema(schemaJson);
+
+        ProcessingReport report = schema.validate(toJsonNode(json));
+        Assert.assertTrue(report.isSuccess(), "Returned Health JSON does not validate against the specification schema");
+    }
+    
+    private JsonNode toJsonNode(JsonObject jsonObject) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readTree(jsonObject.toString());
+    }
+}
+

--- a/tck/src/main/resources/health-check-schema.json
+++ b/tck/src/main/resources/health-check-schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string"
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object",
+            "patternProperties": {
+              "[a-zA-Z_]*": {
+                "type": [
+                  "string",
+                  "boolean",
+                  "number"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "name",
+          "status"
+        ]
+      }
+    }
+  },
+  "required": [
+    "status",
+    "checks"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Signed-off-by: xstefank <xstefank122@gmail.com>

This PR is adding new dependency - json-schema-validator.
Unfortunately, it seems that JSON-P/B don't support schema validation and I am unable to find where to file feature requests for these specs. In every case it will take some time and that's why I've decided for third party dependency.