### PR TITLE
Added JavaDoc for clarification

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
@@ -38,7 +38,6 @@ import java.util.logging.Logger;
  * The HealthCheckResponse class is reserved for an extension by implementation providers.
  * An application should use one of the static methods to create a Response instance using a HealthCheckResponseBuilder.
  * </p>
- *
  */
 public abstract class HealthCheckResponse {
 
@@ -55,11 +54,24 @@ public abstract class HealthCheckResponse {
         HealthCheckResponse.provider = provider;
     }
 
+    /**
+     * Creates a health check response builder with a name.
+     *
+     * @param name the check name
+     * @return a new health check builder with a name
+     */
     public static HealthCheckResponseBuilder named(String name) {
 
         return getProvider().createResponseBuilder().name(name);
     }
 
+    /**
+     * Creates an empty health check response builder.
+     *
+     * <b>Note:</b> The health check response name is required and needs to be set before the response is constructed.
+     *
+     * @return an new, empty health check builder
+     */
     public static HealthCheckResponseBuilder builder() {
         return getProvider().createResponseBuilder();
     }
@@ -85,7 +97,7 @@ public abstract class HealthCheckResponse {
 
     // the actual contract
 
-    public enum State { UP, DOWN }
+    public enum State {UP, DOWN}
 
     public abstract String getName();
 
@@ -98,12 +110,12 @@ public abstract class HealthCheckResponse {
         T serviceInstance = find(service, HealthCheckResponse.getContextClassLoader());
 
         // alternate classloader
-        if(null==serviceInstance) {
+        if (null == serviceInstance) {
             serviceInstance = find(service, HealthCheckResponse.class.getClassLoader());
         }
 
         // service cannot be found
-        if(null==serviceInstance) {
+        if (null == serviceInstance) {
             throw new IllegalStateException("Unable to find service " + service.getName());
         }
 
@@ -126,8 +138,7 @@ public abstract class HealthCheckResponse {
                 }
                 serviceInstance = spi;
             }
-        }
-        catch (Throwable t) {
+        } catch (Throwable t) {
             LOGGER.log(Level.SEVERE, "Error loading service " + service.getName() + ".", t);
         }
 
@@ -135,14 +146,12 @@ public abstract class HealthCheckResponse {
     }
 
 
-
     private static ClassLoader getContextClassLoader() {
         return AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> {
             ClassLoader cl = null;
             try {
                 cl = Thread.currentThread().getContextClassLoader();
-            }
-            catch (SecurityException ex) {
+            } catch (SecurityException ex) {
                 LOGGER.log(
                         Level.WARNING,
                         "Unable to get context classloader instance.",

--- a/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponseBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponseBuilder.java
@@ -22,6 +22,8 @@
 
 package org.eclipse.microprofile.health;
 
+import static org.eclipse.microprofile.health.HealthCheckResponse.State;
+
 /**
  * A builder to construct a health procedure response.
  *
@@ -31,20 +33,78 @@ package org.eclipse.microprofile.health;
  */
 public abstract class HealthCheckResponseBuilder {
 
+    /**
+     * Sets the name of the health check response.
+     *
+     * <b>Note:</b> The health check response name is required and needs to be set before the response is constructed.
+     *
+     * @param name The health check response name
+     * @return this builder
+     */
     public abstract HealthCheckResponseBuilder name(String name);
 
+    /**
+     * Adds additional string data to the health check response.
+     * Puts the {@value} identified by {@code key} to the data section of the health check response.
+     * Additional invocations of a {@code withData} method with the same {@code key} override the key-value pair.
+     *
+     * @param key   the identifier
+     * @param value the value
+     * @return this builder
+     */
     public abstract HealthCheckResponseBuilder withData(String key, String value);
 
+    /**
+     * Adds additional numeric data to the health check response.
+     * Puts the long {@value} identified by {@code key} to the data section of the health check response.
+     * Additional invocations of a {@code withData} method with the same {@code key} override the key-value pair.
+     *
+     * @param key   the identifier
+     * @param value the value
+     * @return this builder
+     */
     public abstract HealthCheckResponseBuilder withData(String key, long value);
 
+    /**
+     * Adds additional boolean data to the health check response.
+     * Puts the boolean {@value} identified by {@code key} to the data section of the health check response.
+     * Additional invocations of a {@code withData} method with the same {@code key} override the key-value pair.
+     *
+     * @param key   the identifier
+     * @param value the value
+     * @return this builder
+     */
     public abstract HealthCheckResponseBuilder withData(String key, boolean value);
 
+    /**
+     * Sets the status of the health check response to {@link State#UP}.
+     * This implies that the health check was successful.
+     *
+     * @return this builder
+     */
     public abstract HealthCheckResponseBuilder up();
 
+    /**
+     * Sets the status of the health check response to {@link State#DOWN}.
+     * This implies that the health check was <i>not</i> successful.
+     *
+     * @return this builder
+     */
     public abstract HealthCheckResponseBuilder down();
 
+    /**
+     * Sets the status of the health check response according to the boolean value {@code up}.
+     *
+     * @param up the status
+     * @return this builder
+     */
     public abstract HealthCheckResponseBuilder state(boolean up);
 
+    /**
+     * Creates a health check response from the current builder.
+     *
+     * @return The health check response
+     */
     public abstract HealthCheckResponse build();
 
 }

--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -128,6 +128,7 @@ public class SuccessfulCheck implements HealthCheck {
 
 The `name` is used to tell the different checks apart when a human operator looks at the responses.
 It may be that one check of several fails and it's useful to know which one.
+It's required that a response defines a name.
 
 `HealthCheckResponse` 's also support a free-form information holder, that can be used to supply arbitrary data to the consuming end:
 


### PR DESCRIPTION
Added some JavaDoc and a note to the spec document.

Especially the need for a named health check response made me run into errors when using `HealthCheckResponse#builder()` without setting a name.