### PR TITLE
Add CDIProducedProcedureTest TCK and fix Javadoc

### DIFF
--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2017 Eclipse Microprofile Contributors:
+// Copyright (c) 2016-2019 Eclipse Microprofile Contributors:
 // See overview.adoc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -171,17 +171,15 @@ Health check procedures are CDI beans, therefore, they can also be defined with 
 class MyChecks {
 
   @Produces
-  @ApplicationScoped
   @Liveness
   HealthCheck check1() {
-    return () -> HealthStatus.state(getMemUsage() < 0.9);
+    return () -> HealthCheckResponse.state(getMemUsage() < 0.9);
   }
 
   @Produces
-  @ApplicationScoped
   @Readiness
   HealthCheck check2() {
-    return () -> HealthStatus.state(getCpuUsage() < 0.9);
+    return () -> HealthCheckResponse.state(getCpuUsage() < 0.9);
   }
-}}
+}
 ```

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/CDIProducedProceduresTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/CDIProducedProceduresTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.microprofile.health.tck;
+
+import static org.eclipse.microprofile.health.tck.DeploymentUtils.createWarFileWithClasses;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import org.eclipse.microprofile.health.tck.deployment.CDIProducedProcedureCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Prashanth Gunapalasingam
+ */
+public class CDIProducedProceduresTest extends TCKBase {
+    @Deployment
+    public static Archive getDeployment() {
+        return createWarFileWithClasses(CDIProducedProcedureCheck.class);
+    }
+
+    /**
+     * Verifies the liveness and readiness health integration with CDI when the
+     * Health Check procedures are defined with CDI Producers.
+     */
+    @Test
+    @RunAsClient
+    public void testSuccessfulLivenessResponsePayload() {
+        Response response = getUrlLiveContents();
+
+        // status code
+        Assert.assertEquals(response.getStatus(), 200);
+
+        JsonObject json = readJson(response);
+
+        // response size
+        JsonArray checks = json.getJsonArray("checks");
+        Assert.assertEquals(checks.size(), 1, "Expected one check responses");
+
+        // single procedure response
+        assertSuccessfulCheck(checks.getJsonObject(0), "cdi-produced-successful-check");
+
+        assertOverallSuccess(json);
+    }
+
+    /**
+     * Tests that Readiness is down, for Readiness health check procedure
+     * defined with CDI Producers.
+     */
+    @Test
+    @RunAsClient
+    public void testFailureReadinessResponsePayload() {
+        Response response = getUrlReadyContents();
+
+        // status code
+        Assert.assertEquals(response.getStatus(), 503);
+
+        JsonObject json = readJson(response);
+
+        // response size
+        JsonArray checks = json.getJsonArray("checks");
+        Assert.assertEquals(checks.size(), 1, "Expected a single check response");
+
+        // single procedure response
+        assertFailureCheck(checks.getJsonObject(0), "cdi-produced-failed-check");
+
+        assertOverallFailure(json);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CDIProducedProcedureCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/CDIProducedProcedureCheck.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.microprofile.health.tck.deployment;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+import org.eclipse.microprofile.health.Readiness;
+
+@ApplicationScoped
+public class CDIProducedProcedureCheck {
+    @Produces
+    @Liveness
+    HealthCheck cdiProducedLivenessCheck() {
+        return () -> HealthCheckResponse.named("cdi-produced-successful-check").up().build();
+    }
+
+    @Produces
+    @Readiness
+    HealthCheck cdiProducedReadinessCheck() {
+        return () -> HealthCheckResponse.named("cdi-produced-failed-check").down().build();
+    }
+}


### PR DESCRIPTION
Signed-off-by: pgunapal pgunapal@ca.ibm.com

Created a TCK test case for CDI produced Health Check procedures and fixed the corresponding java-api Javadoc.