### PR TITLE
microprofile-health-195 Exclude EL API transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
                 <groupId>javax.enterprise</groupId>
                 <artifactId>cdi-api</artifactId>
                 <version>${cdi-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.el</groupId>
+                        <artifactId>javax.el-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>


### PR DESCRIPTION
fixes #195

For the record, CDI is only used in TCK. API only used AtInject specification

Signed-off-by: Antoine Sabot-Durand <antoine@sabot-durand.net>