### PR TITLE
microprofile-health-194 Better integration with JSON-B and MP Rest Cient

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
@@ -38,13 +38,41 @@ import java.util.logging.Logger;
  * The {@link HealthCheckResponse} class is reserved for an extension by implementation providers.
  * An application should use one of the static methods to create a Response instance using a 
  * {@link HealthCheckResponseBuilder}.
+ * When used on the consuming, The class can also be instantiated directly.
  * </p>
  */
-public abstract class HealthCheckResponse {
+public class HealthCheckResponse {
 
     private static final Logger LOGGER = Logger.getLogger(HealthCheckResponse.class.getName());
 
     private static volatile HealthCheckResponseProvider provider = null;
+
+    private final String name;
+
+    private final State state;
+
+    private final Optional<Map<String, Object>> data;
+
+    /**
+     * Constructor allowing instantiation from 3rd party framework like MicroProfile Rest client
+     * @param name Health Check procedure's name
+     * @param state Health Check procedure's state
+     * @param data date for Health Check procedure
+     */
+    public HealthCheckResponse(String name, State state, Optional<Map<String, Object>> data) {
+        this.name = name;
+        this.state = state;
+        this.data = data;
+    }
+
+    /**
+     * Default constructor
+     */
+    public HealthCheckResponse() {
+        name = null;
+        state = null;
+        data = null;
+    }
 
     /**
      * Used by OSGi environment where the service loader pattern is not supported.
@@ -120,11 +148,17 @@ public abstract class HealthCheckResponse {
 
     public enum State {UP, DOWN}
 
-    public abstract String getName();
+    public String getName(){
+        return name;
+    }
 
-    public abstract State getState();
+    public State getState(){
+        return state;
+    }
 
-    public abstract Optional<Map<String, Object>> getData();
+    public Optional<Map<String, Object>> getData() {
+        return data;
+    }
 
     private static <T> T find(Class<T> service) {
 

--- a/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
  * The {@link HealthCheckResponse} class is reserved for an extension by implementation providers.
  * An application should use one of the static methods to create a Response instance using a 
  * {@link HealthCheckResponseBuilder}.
- * When used on the consuming, The class can also be instantiated directly.
+ * When used on the consuming end, The class can also be instantiated directly.
  * </p>
  */
 public class HealthCheckResponse {
@@ -57,7 +57,7 @@ public class HealthCheckResponse {
      * Constructor allowing instantiation from 3rd party framework like MicroProfile Rest client
      * @param name Health Check procedure's name
      * @param state Health Check procedure's state
-     * @param data date for Health Check procedure
+     * @param data additional data for Health Check procedure
      */
     public HealthCheckResponse(String name, State state, Optional<Map<String, Object>> data) {
         this.name = name;

--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -145,7 +145,7 @@ public class CheckDiskspace implements HealthCheck {
 }
 ```
 
-`HealthCheckResponse` also provides default constructors to allow instantiation on the consuming end.
+`HealthCheckResponse` also provides a constructor to allow instantiation on the consuming end.
 
 == Integration with CDI
 

--- a/spec/src/main/asciidoc/java-api.adoc
+++ b/spec/src/main/asciidoc/java-api.adoc
@@ -76,7 +76,7 @@ If more than one `HealthCheck` are invoked, they will be called in an unpredicta
 The runtime will `call()` each `HealthCheck` which in turn creates a `HealthCheckResponse` that signals the health status to a consuming end:
 
 ```
-public abstract class HealthCheckResponse {
+public class HealthCheckResponse {
 
     public enum State { UP, DOWN }
 
@@ -144,6 +144,8 @@ public class CheckDiskspace implements HealthCheck {
     }
 }
 ```
+
+`HealthCheckResponse` also provides default constructors to allow instantiation on the consuming end.
 
 == Integration with CDI
 


### PR DESCRIPTION
fixes #194

Make HealthCheckResponse a concrete class and add constructors for backward compatibility and usage on the consuming end from MP RestClient

Signed-off-by: Antoine Sabot-Durand <antoine@sabot-durand.net>