### PR TITLE
issue-244 Add configuration value for the default readiness statuses …

### DIFF
--- a/spec/src/main/asciidoc/protocol-wireformat.adoc
+++ b/spec/src/main/asciidoc/protocol-wireformat.adoc
@@ -131,8 +131,22 @@ Each provider MUST provide the REST/HTTP interaction, but MAY provide other prot
 == Health Check Procedures
 * A producer MUST support custom, application level health check procedures
 * A producer SHOULD support reasonable out-of-the-box procedures
-* A producer with no health check procedures expected or installed MUST return positive overall status (i.e. HTTP 200)
-* A producer with health check procedures expected but not yet installed MUST return negative overall status (i.e. HTTP 503)
+
+* A producer with no liveness procedures expected or installed MUST return positive overall status (i.e. HTTP 200)
+* A producer with no readiness procedures expected or installed MUST return positive overall status (i.e. HTTP 200)
+
+* A producer with liveness procedures expected but not yet installed MUST return positive overall status (i.e. HTTP 200)
+* A producer with readiness procedures expected but not yet installed MUST return negative overall status (i.e. HTTP 503)
+
+A producer with no procedures expected or installed can be for instance 
+an application server without any deployments (focusing on some different function).
+
+A producer with procedures expected but not yet installed can be for instance a
+standalone runtime packaged with the user application, or
+an application server with already deployed user applications. User defined health
+check procedures thus can be expected but they do not have to be already processed
+when the first invocations of `/health/*` endpoints are received. See also 
+the <<empty-readiness, Empty default readiness health check responses>> section.
 
 === Policies to determine the overall status
 
@@ -141,6 +155,20 @@ When multiple procedures are installed all procedures MUST be executed and the o
 * Consumers MUST support a logical conjunction policy to determine the status
 * Consumers MUST use the logical conjunction policy by default to determine the status
 * Consumers MAY support custom policies to determine the status
+
+[[empty-readiness]]
+== Empty default readiness health check responses
+
+As readiness determines whether the container may consume requests, the container
+is <<health-check-procedures, required to return negative overall status>> 
+until the user defined readiness checks can be executed. However, in some cases
+(e.g. the containers allowing multiple deployments) the container itself may be
+required to become ready before user defined readiness procedures can be deployed.
+This means that the container cannot know whether some procedures will be expected.
+For this reason, users are allowed to specify
+https://github.com/eclipse/microprofile-config[MicroProfile Config] configuration
+value `mp.health.default.readiness.empty.response` to `UP` to give the container
+a hint that it can become ready.
 
 ==== Executing procedures
 


### PR DESCRIPTION
…(UP/DOWN) for empty check responses

resolves #244 