### PR TITLE
Cleanup incorrect? "MicroProfile Health Check" spec names in spec/doc.

### DIFF
--- a/spec/src/main/asciidoc/microprofile-health-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-health-spec.adoc
@@ -16,7 +16,7 @@
 //
 
 = MicroProfile Health
-:author: The Microprofile community and it's contributors
+:author: The Microprofile community and its contributors
 :version-label!:
 :sectanchors:
 :doctype: book

--- a/spec/src/main/asciidoc/overview.adoc
+++ b/spec/src/main/asciidoc/overview.adoc
@@ -19,7 +19,7 @@
 
 == Rationale
 
-The Eclipse MicroProfile Health Check specification defines a single container runtime mechanism for validating
+The Eclipse MicroProfile Health specification defines a single container runtime mechanism for validating
 the availability and status of a MicroProfile implementation. This is primarily intended as a machine to machine (M2M)
 mechanism for use in containerized environments like cloud providers. Example of
 existing specifications from those environments include https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html[Cloud Foundry Health Checks] and
@@ -27,22 +27,22 @@ https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-read
 
 In this scenario health checks are used to determine if a computing node needs to be discarded (terminated, shutdown) and eventually replaced by another (healthy) instance.
 
-The MicroProfile Health Check architecture consists of two `/health/ready` and `/health/live` endpoints in a MicroProfile runtime that respectively represent the readiness and the liveness of the entire runtime.
-These endpoints are linked to Health Check procedures defined with specifications API and annotated respectively with `@Liveness` and `@Readiness` annotations.
+The MicroProfile Health architecture consists of two `/health/ready` and `/health/live` endpoints in a MicroProfile runtime that respectively represent the readiness and the liveness of the entire runtime.
+These endpoints are linked to health check procedures defined with specifications API and annotated respectively with `@Liveness` and `@Readiness` annotations.
 
 A 3rd endpoint `/health` is also available and can be used to provide a combination of the previous endpoints.
 
 These endpoints are expected to be associated with a configurable context, such as a web application deployment, that can be configured with settings such as port, virtual-host, security, etc.
-Further, the MicroProfile Health Check defines the notion of a procedure that represents the health of a particular subcomponent of an application.
+Further, MicroProfile Health defines the notion of a procedure that represents the health of a particular subcomponent of an application.
 
 In an application, there can be zero or more procedures bound to a given health endpoint.
 The overall application health for a given endpoint is the logical AND of all of the procedures bound to it.
 
-The current version of the MicroProfile Health Check specification does not define how the defined endpoints may be partitioned in the event
+The current version of the MicroProfile Health specification does not define how the defined endpoints may be partitioned in the event
 that the MicroProfile runtime supports deployment of multiple applications. If an implementation wishes to
 support multiple applications within a MicroProfile runtime, the semantics of individual endpoints are
 expected to be the logical AND of all the application in the runtime. The exact details of this are deferred to
-a future version of the MicroProfile Health Check specification.
+a future version of the MicroProfile Health specification.
 
 == Proposed solution
 

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -21,11 +21,11 @@
 = Release Notes
 
 [[release_notes_2_2]]
-== Release Notes for MicroProfile Health Check 2.2
+== Release Notes for MicroProfile Health 2.2
 
 The following changes occurred in the 2.2 release, compared to 2.1
 
-A full list of changes may be found on the link:https://github.com/eclipse/microprofile-health/milestone/4?closed=1[MicroProfile Health Check 2.2]
+A full list of changes may be found on the link:https://github.com/eclipse/microprofile-health/milestone/4?closed=1[MicroProfile Health 2.2]
 
 === API/SPI Changes
 
@@ -39,16 +39,16 @@ A full list of changes may be found on the link:https://github.com/eclipse/micro
 
 
 [[release_notes_2_1]]
-== Release Notes for MicroProfile Health Check 2.1
+== Release Notes for MicroProfile Health 2.1
 
 The following changes occurred in the 2.1 release, compared to 2.0
 
-A full list of changes may be found on the link:https://github.com/eclipse/microprofile-health/milestone/3?closed=1+[MicroProfile Health Check 2.1]
+A full list of changes may be found on the link:https://github.com/eclipse/microprofile-health/milestone/3?closed=1+[MicroProfile Health 2.1]
 
 === API/SPI Changes
 
 - Add new method to create responses
-- Add config property to disable implementation Health Check procedures
+- Add config property to disable implementation health check procedures
 - Improve javadoc
 
 === TCK enhancement
@@ -63,11 +63,11 @@ A full list of changes may be found on the link:https://github.com/eclipse/micro
 - Remove EL API transitive dependency
 
 [[release_notes_2]]
-== Release Notes for MicroProfile Health Check 2.0
+== Release Notes for MicroProfile Health 2.0
 
 The following changes occurred in the 2.0 release, compared to 1.0
 
-A full list of changes may be found on the link:https://github.com/eclipse/microprofile-health/issues?utf8=✓&q=is%3Aissue+milestone%3A2.0+[MicroProfile Health Check 2.0]
+A full list of changes may be found on the link:https://github.com/eclipse/microprofile-health/issues?utf8=✓&q=is%3Aissue+milestone%3A2.0+[MicroProfile Health 2.0]
 
 === API/SPI Changes
 


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Went looking for whether the official name was "MP Health" vs. "MP Health Check".

I found this discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/microprofile/eyz7MSIFUVg/-siZRL6pAgAJ

So I submitted this PR.   I won't feel bad if it turns out you already discussed this... seemed easier to just send a PR than start another discussion.