### PR TITLE
Updated the org.glassfish.jakarta.json version in TCK to align with Jakarta EE 9.1

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -26,7 +26,7 @@
     <name>MicroProfile Health TCK</name>
 
     <properties>
-        <version.glassfish.json>1.1.6</version.glassfish.json>
+        <version.glassfish.json>2.0.0</version.glassfish.json>
         <httpclient.version>4.5.2</httpclient.version>
         <version.com.github.java-json-tools>2.2.10</version.com.github.java-json-tools>
     </properties>


### PR DESCRIPTION
Signed-off-by: Prashanth G <pgunapal@ca.ibm.com>

Need to update the `org.glassfish.jakarta.json` version to 2.0.0 in the TCK dependency, to align with Jakarta EE 9.1, in order for the TCKs to run properly with the jakarta.json APIs.