### PR TITLE
[issue-325] - Add tests to verify that HealthCheckResponse has a name when built as recommended on the producer side

### DIFF
--- a/spec/src/main/asciidoc/java-api.asciidoc
+++ b/spec/src/main/asciidoc/java-api.asciidoc
@@ -129,7 +129,9 @@ public class SuccessfulCheck implements HealthCheck {
 
 The `name` is used to tell the different checks apart when a human operator looks at the responses.
 It may be that one check of several fails and it's useful to know which one.
-It's required that a response defines a name.
+It's required that a response defines a name, i.e. implementations must verify that a consistent name is provided when
+constructing a `HealthCheckResponse` instance, and fail accordingly if it is not.
+Specific tests to verify this behavior are executed when running the TCKs.
 
 `HealthCheckResponse` 's also support a free-form information holder, that can be used to supply arbitrary data to the consuming end:
 

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/EmptyNameHealthCheckResponseTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/EmptyNameHealthCheckResponseTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019-2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.microprofile.health.tck;
+
+import org.eclipse.microprofile.health.tck.deployment.EmptyNameCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+
+/**
+ * @author Fabio Burzigotti
+ */
+public class EmptyNameHealthCheckResponseTest extends TCKBase {
+
+    @Deployment
+    public static Archive getDeployment() {
+        return DeploymentUtils.createWarFileWithClasses(EmptyNameHealthCheckResponseTest.class.getSimpleName(),
+                EmptyNameCheck.class, TCKBase.class);
+    }
+
+    /**
+     * Verifies that defining a HealthCheckResponse with an empty name will cause the runtime to return HTTP 503
+     */
+    @Test
+    @RunAsClient
+    public void testStartupFailsWithException() {
+        Response response = getUrlStartedContents();
+
+        // status code
+        Assert.assertEquals(response.getStatus(), 503);
+
+        JsonObject json = readJson(response);
+
+        // response size
+        JsonArray checks = json.getJsonArray("checks");
+        Assert.assertEquals(checks.size(), 1, "Expected a single check response");
+
+        assertOverallFailure(json);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/NullNameHealthCheckResponseTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/NullNameHealthCheckResponseTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019-2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.eclipse.microprofile.health.tck;
+
+import org.eclipse.microprofile.health.tck.deployment.NullNameCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+
+/**
+ * @author Fabio Burzigotti
+ */
+public class NullNameHealthCheckResponseTest extends TCKBase {
+
+    @Deployment
+    public static Archive getDeployment() {
+        return DeploymentUtils.createWarFileWithClasses(NullNameHealthCheckResponseTest.class.getSimpleName(),
+                NullNameCheck.class, TCKBase.class);
+    }
+
+    /**
+     * Verifies that defining a HealthCheckResponse with a null name will cause the runtime to return HTTP 503
+     */
+    @Test
+    @RunAsClient
+    public void testStartupFailsWithException() {
+        Response response = getUrlStartedContents();
+
+        // status code
+        Assert.assertEquals(response.getStatus(), 503);
+
+        JsonObject json = readJson(response);
+
+        // response size
+        JsonArray checks = json.getJsonArray("checks");
+        Assert.assertEquals(checks.size(), 1, "Expected a single check response");
+
+        assertOverallFailure(json);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/EmptyNameCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/EmptyNameCheck.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck.deployment;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@Startup
+@ApplicationScoped
+public class EmptyNameCheck implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.up("");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/NullNameCheck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/deployment/NullNameCheck.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.eclipse.microprofile.health.tck.deployment;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Startup;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@Startup
+@ApplicationScoped
+public class NullNameCheck implements HealthCheck {
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.up(null);
+    }
+}


### PR DESCRIPTION
SSIA.

Fixes #325 

TCKs are running fine, see last comment