### PR TITLE
Changing the visibility of TCKBase and DeploymentUtils methods, for reuse in subclasses (e.g.: additional vendor tests)

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/DeploymentUtils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/DeploymentUtils.java
@@ -26,16 +26,16 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-class DeploymentUtils {
+public class DeploymentUtils {
     private DeploymentUtils() {
     }
 
-    static WebArchive createEmptyWarFile(String name) {
+    public static WebArchive createEmptyWarFile(String name) {
         return ShrinkWrap.create(WebArchive.class, name + ".war")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    static WebArchive createWarFileWithClasses(String name, Class<?>... classes) {
+    public static WebArchive createWarFileWithClasses(String name, Class<?>... classes) {
         return createEmptyWarFile(name)
                 .addClasses(classes);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/health/tck/TCKBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/health/tck/TCKBase.java
@@ -63,19 +63,19 @@ public abstract class TCKBase extends Arquillian {
         LOG.info(String.format("Running test: %s#%s", method.getDeclaringClass().getSimpleName(), method.getName()));
     }
 
-    Response getUrlHealthContents() {
+    protected Response getUrlHealthContents() {
         return getUrlContents(this.uri + "/health", false);
     }
 
-    Response getUrlLiveContents() {
+    protected Response getUrlLiveContents() {
         return getUrlContents(this.uri + "/health/live", false);
     }
 
-    Response getUrlReadyContents() {
+    protected Response getUrlReadyContents() {
         return getUrlContents(this.uri + "/health/ready", false);
     }
 
-    Response getUrlStartedContents() {
+    protected Response getUrlStartedContents() {
         return getUrlContents(this.uri + "/health/started", false);
     }
 
@@ -127,7 +127,7 @@ public abstract class TCKBase extends Arquillian {
         return new Response(code, content.toString());
     }
 
-    JsonObject readJson(Response response) {
+    protected JsonObject readJson(Response response) {
         JsonReader jsonReader = Json.createReader(new StringReader(response.getBody().get()));
         JsonObject json = jsonReader.readObject();
         System.out.println(json);
@@ -135,12 +135,12 @@ public abstract class TCKBase extends Arquillian {
         return json;
     }
 
-    void assertSuccessfulCheck(JsonObject check, String expectedName) {
+    protected void assertSuccessfulCheck(JsonObject check, String expectedName) {
         assertCheckName(check, expectedName);
         verifySuccessStatus(check);
     }
 
-    void assertFailureCheck(JsonObject check, String expectedName) {
+    protected void assertFailureCheck(JsonObject check, String expectedName) {
         assertCheckName(check, expectedName);
         verifyFailureStatus(check);
     }
@@ -153,7 +153,7 @@ public abstract class TCKBase extends Arquillian {
                         "but it was not present in the response", expectedName));
     }
 
-    void verifySuccessStatus(JsonObject check) {
+    protected void verifySuccessStatus(JsonObject check) {
         Assert.assertEquals(
                 check.getString("status"),
                 "UP",
@@ -161,21 +161,21 @@ public abstract class TCKBase extends Arquillian {
 
     }
 
-    void verifyFailureStatus(JsonObject check) {
+    protected void verifyFailureStatus(JsonObject check) {
         Assert.assertEquals(
                 check.getString("status"),
                 "DOWN",
                 "Expected a failed check result");
     }
 
-    void assertOverallSuccess(JsonObject json) {
+    protected void assertOverallSuccess(JsonObject json) {
         Assert.assertEquals(
                 json.getString("status"),
                 "UP",
                 "Expected overall status to be successful");
     }
 
-    void assertOverallFailure(JsonObject json) {
+    protected void assertOverallFailure(JsonObject json) {
         Assert.assertEquals(
                 json.getString("status"),
                 "DOWN",


### PR DESCRIPTION
Initially related to #327

**Update**:
This no longer fix the above linked issue, which will be most likely closed.

The reason is that it is not advisable to alter the process for TCK users, by adding one more `surefire` execution for testing _the way_ a a MP Config property is set, being it passed via a system property, an environment variable, or a `microprofile-config.properties` file.

Instead, this PR is proposing a change to the visibility of some `TCKBase` methods, so that an additional test in the integration codebase could use them. The same applies to the only change to the `DeploymentUtils` class.

FYI @xstefank 