### PR TITLE
Refactoring HealthCheckResponse to remove Optional from the data field

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -50,7 +50,27 @@ public class HealthCheckResponse {
 
     private final Status status;
 
-    private final Optional<Map<String, Object>> data;
+    private final Map<String, Object> data;
+
+    /**
+     * Constructor allowing instantiation from 3rd party framework like MicroProfile Rest client
+     * <p>
+     * This is deprecated since MicroProfile Health 4.1, and will be removed in the next major version.
+     * {@link HealthCheckResponse#HealthCheckResponse(String, Status, Map)} should be used from now on.
+     *
+     * @param name
+     *            Health Check procedure's name
+     * @param status
+     *            Health Check procedure's status
+     * @param data
+     *            additional data for Health Check procedure
+     */
+    @Deprecated(since = "4.1", forRemoval = true)
+    public HealthCheckResponse(String name, Status status, Optional<Map<String, Object>> data) {
+        this.name = name;
+        this.status = status;
+        this.data = data.orElse(null);
+    }
 
     /**
      * Constructor allowing instantiation from 3rd party framework like MicroProfile Rest client
@@ -62,7 +82,7 @@ public class HealthCheckResponse {
      * @param data
      *            additional data for Health Check procedure
      */
-    public HealthCheckResponse(String name, Status status, Optional<Map<String, Object>> data) {
+    public HealthCheckResponse(String name, Status status, Map<String, Object> data) {
         this.name = name;
         this.status = status;
         this.data = data;
@@ -72,9 +92,9 @@ public class HealthCheckResponse {
      * Default constructor
      */
     public HealthCheckResponse() {
-        name = null;
-        status = null;
-        data = null;
+        this.name = null;
+        this.status = null;
+        this.data = null;
     }
 
     /**
@@ -165,8 +185,21 @@ public class HealthCheckResponse {
         return status;
     }
 
+    /**
+     * Access the map which stores the Health check response data.
+     * <p>
+     * This is deprecated since MicroProfile Health 4.1, and will be replaced by
+     * {@code public Map<String, Object> getData()} in the next major version.
+     *
+     * @return An {@link Optional} instance to contain the Health check response data.
+     */
+    @Deprecated(since = "4.1")
     public Optional<Map<String, Object>> getData() {
-        return data;
+        return Optional.ofNullable(data);
+    }
+
+    public Optional<Object> getData(String key) {
+        return Optional.of(data.get(key));
     }
 
     private static <T> T find(Class<T> service) {

--- a/api/src/main/java/org/eclipse/microprofile/health/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/health/package-info.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2016-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,5 +23,5 @@
  * Microprofile Health
  * </p>
  **/
-@org.osgi.annotation.versioning.Version("3.0")
+@org.osgi.annotation.versioning.Version("3.1")
 package org.eclipse.microprofile.health;

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2021 Contributors to the Eclipse Foundation
+// Copyright (c) 2016-2024 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -21,6 +21,37 @@
 [[release_notes]]
 == Release Notes
 This section documents the changes introduced by individual releases.
+
+[[release_notes_4_1]]
+=== Release Notes for MicroProfile Health 4.1
+
+The following changes occurred in the 4.1 release, compared to 4.0.
+
+A full list of changes may be found on the link:https://github.com/eclipse/microprofile-health/milestone/8[Future]
+
+==== Incompatible Changes
+
+- None
+
+==== API/SPI Changes
+
+- The existing link:../../../../api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java[`HealthCheckResponse(String, Status, Optional<Map<String, Object>>)`]
+constructor has been deprecated since this release, see https://github.com/eclipse/microprofile-health/issues/323.
+Therefore, the method signature will be refactored accordingly in the next MicroProfile Health major release (5.0).
+A new constructor has been defined as `HealthCheckResponse(String, Status, Map<String, Object>)`, and should be used
+from now on.
+
+- link:../../../../api/src/main/java/org/eclipse/microprofile/health/HealthCheckResponse.java[`HealthCheckResponse::getData`]
+has been deprecated since this release, see https://github.com/eclipse/microprofile-health/issues/323, hence the method
+signature will be refactored accordingly in the next MicroProfile Health major release (5.0).
+
+==== Functional Changes
+
+- None
+
+==== Other Changes
+
+- None
 
 [[release_notes_4_0]]
 === Release Notes for MicroProfile Health 4.0


### PR DESCRIPTION
Quick attempt at refactoring `HealthCheckResponse` to use just `Map<>` as the data type for the `data` field.
This is a breaking change, since the ctor is affected, hence the `microprofile-health-api` version is bumped as well.

~**Draft**, since the changes require #331 (rebased on it temporarily)~

Fixes #323

FYI @xstefank